### PR TITLE
Implement more common traits for Viewport

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ extern crate float;
 use float::*;
 
 /// Stores viewport information.
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Viewport {
     /// Viewport in pixels.
     /// ```[x, y, width height]``` where ```(x, y)``` is lower left corner.


### PR DESCRIPTION
This PR adds more trait derives for `Debug`, `PartialEq`, `Eq`, and `Hash`, which seem to make sense for this kind of structure. At least, not having `Debug` was a bit surprising to me.
This also provides better compliance to the [C-COMMON-TRAITS](https://rust-lang-nursery.github.io/api-guidelines/interoperability.html#c-common-traits) guideline.